### PR TITLE
Add experimental debug feature to the Messenger

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 import { ParentHandshake, ChildHandshake } from './handshake';
 import { Connection } from './connection';
-import { Messenger, WindowMessenger, WorkerMessenger } from './messenger';
+import {
+  Messenger,
+  WindowMessenger,
+  WorkerMessenger,
+  DebugMessenger,
+  debug,
+} from './messenger';
 import { RemoteHandle, LocalHandle } from './handle';
 
 export {
@@ -12,4 +18,6 @@ export {
   Messenger,
   WindowMessenger,
   WorkerMessenger,
+  DebugMessenger,
+  debug,
 };

--- a/src/messenger.ts
+++ b/src/messenger.ts
@@ -85,3 +85,34 @@ export class WorkerMessenger implements Messenger {
     };
   }
 }
+
+export const debug = (namespace: string, log?: (...data: any[]) => void) => {
+  log = log || console.debug || console.log || (() => {});
+  return (...data: any[]) => {
+    log!(namespace, ...data);
+  };
+};
+
+export function DebugMessenger(
+  messenger: Messenger,
+  log?: (...data: any[]) => void
+): Messenger {
+  log = log || debug('ibridge');
+
+  const debugListener: MessageListener = function (event) {
+    const { data } = event;
+    log!('⬅️ received message', data);
+  };
+
+  messenger.addMessageListener(debugListener);
+
+  return {
+    postMessage: function (message) {
+      log!('➡️ sending message', message);
+      messenger.postMessage(message);
+    },
+    addMessageListener: function (listener) {
+      return messenger.addMessageListener(listener);
+    },
+  };
+}


### PR DESCRIPTION
I'm proposing an implementation to easily provide a visual debug of every message sent/received at the `Messenger` level.
Let's start a discussion, this PR is not meant to be merged yet (will write docs and tests once we settle on an implementation).

Usage:
```typescript
import {
  ParentHandshake,
  WindowMessenger,
  DebugMessenger,
} from 'ibridge';

import debug from 'debug';

let messenger = new WindowMessenger({
  localWindow: window,
  remoteWindow: childWindow,
  remoteOrigin: '*'
});

const log = debug('ibridge:parent');
messenger = DebugMessenger(messenger, log);

cost handshake = ParentHandshake({}, messenger);
...
```

What I like:
- Debugging at the `Messenger` level ensure that every single message exchanged gets logged.
- Debugging code is localized to a single 10 line function, instead of being scattered in several places such as the `Bridge`/`Handshake`.
- Since `DebugMessenger` is a decorator (i.e. takes a `Messenger` and returns a `Messenger`), it will automatically work with any new type of `Messenger` we may implement in the future.
- Zero runtime cost when debugging is disabled, don't even need to call no-op or have if/else checks, just don't decorate the `Messenger` before passing it to the handshake.
- The implementation works great with the popular `debug` library (see screenshot),

Here is a screenshot of the debug output of the demo application:
![ibridge_debug_output](https://user-images.githubusercontent.com/15913822/103419538-76160e80-4b61-11eb-89da-24f15a4fa74b.png)
