### PR TITLE
Add optional debugging of each message exchanged

### DIFF
--- a/demo/child.html
+++ b/demo/child.html
@@ -11,6 +11,7 @@
   <body>
     <div id="container" class="root"></div>
     <noscript>You need to enable JavaScript to run this app.</noscript>
+    <script src="https://unpkg.com/debug-browser/dist/index.js"></script>
     <script type="module" src="./child.js"></script>
   </body>
 

--- a/demo/child.js
+++ b/demo/child.js
@@ -1,4 +1,11 @@
-import { ChildHandshake, WindowMessenger } from './post-me.esm.js';
+import {
+  ChildHandshake,
+  WindowMessenger,
+  DebugMessenger,
+} from './post-me.esm.js';
+
+const debugNamespace = `post-me:${window.name}`;
+debug.enable(debugNamespace);
 
 let title = '';
 let color = '#ffffff';
@@ -22,11 +29,13 @@ const methods = {
   },
 };
 
-const messenger = new WindowMessenger({
+const log = debug(debugNamespace);
+let messenger = new WindowMessenger({
   localWindow: window,
   remoteWindow: window.parent,
   remoteOrigin: '*',
 });
+messenger = DebugMessenger(messenger, log);
 ChildHandshake(methods, messenger).then((connection) => {
   const localHandle = connection.localHandle();
   const remoteHandle = connection.remoteHandle();

--- a/demo/index.html
+++ b/demo/index.html
@@ -27,6 +27,8 @@
     </div>
     <noscript>You need to enable JavaScript to run this app.</noscript>
   </body>
+
+  <script src="https://unpkg.com/debug-browser/dist/index.js"></script>
   <script type="module" src="./parent.js"></script>
 
   <style>

--- a/demo/parent.js
+++ b/demo/parent.js
@@ -2,7 +2,12 @@ import {
   ParentHandshake,
   WindowMessenger,
   WorkerMessenger,
+  DebugMessenger,
 } from './post-me.esm.js';
+
+debug.enable(
+  'post-me:parent0,post-me:parent1,post-me:parent2,post-me:parent3,post-me:parentW'
+);
 
 let title = 'Parent';
 let color = '#eeeeee';
@@ -50,6 +55,7 @@ const createChildWindow = (i) => {
   return new Promise((resolve) => {
     const childContainer = document.getElementById(`child${i}-container`);
     const childFrame = document.createElement('iframe');
+    childFrame.name = `child${i}`;
     childFrame.src = './child.html';
     childFrame.width = '100%';
     childFrame.height = '100%';
@@ -62,11 +68,13 @@ const createChildWindow = (i) => {
 };
 
 const makeHandshake = (i, childWindow) => {
-  const messenger = new WindowMessenger({
+  const log = debug(`post-me:parent${i}`);
+  let messenger = new WindowMessenger({
     localWindow: window,
     remoteWindow: childWindow,
     remoteOrigin: '*',
   });
+  messenger = DebugMessenger(messenger, log);
   return ParentHandshake(methods, messenger);
 };
 
@@ -160,8 +168,9 @@ children.forEach((i) => initChild(i));
 // Create the worker
 {
   const worker = new Worker('./worker.js');
-
-  const messenger = new WorkerMessenger({ worker });
+  const log = debug('post-me:parentW');
+  let messenger = new WorkerMessenger({ worker });
+  messenger = DebugMessenger(messenger, log);
 
   ParentHandshake({}, messenger).then((connection) => {
     const remoteHandle = connection.remoteHandle();

--- a/demo/worker.js
+++ b/demo/worker.js
@@ -1,12 +1,17 @@
+importScripts('https://unpkg.com/debug-browser/dist/index.js');
 importScripts('./post-me.umd.js');
-const PostMe = self['post-me'];
+
+const postMe = self['post-me'];
+const debug = self['debug'];
+
+debug.enable('post-me:worker');
 
 const methods = {
   sum: (x, y) => x + y,
   mul: (x, y) => x * y,
 };
 
-const messenger = new PostMe.WorkerMessenger({ worker: self });
-PostMe.ChildHandshake(methods, messenger).then((_connection) => {
-  console.log('Worker successfully connected');
-});
+const log = debug('post-me:worker');
+let messenger = new postMe.WorkerMessenger({ worker: self });
+messenger = postMe.DebugMessenger(messenger, log);
+postMe.ChildHandshake(methods, messenger).then((_connection) => {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 import { ParentHandshake, ChildHandshake } from './handshake';
 import { Connection } from './connection';
-import { Messenger, WindowMessenger, WorkerMessenger } from './messenger';
+import {
+  Messenger,
+  WindowMessenger,
+  WorkerMessenger,
+  DebugMessenger,
+  debug,
+} from './messenger';
 import { RemoteHandle, LocalHandle } from './handle';
 
 export {
@@ -12,4 +18,6 @@ export {
   Messenger,
   WindowMessenger,
   WorkerMessenger,
+  DebugMessenger,
+  debug,
 };

--- a/src/messenger.ts
+++ b/src/messenger.ts
@@ -85,3 +85,34 @@ export class WorkerMessenger implements Messenger {
     };
   }
 }
+
+export const debug = (namespace: string, log?: (...data: any[]) => void) => {
+  log = log || console.debug || console.log || (() => {});
+  return (...data: any[]) => {
+    log!(namespace, ...data);
+  };
+};
+
+export function DebugMessenger(
+  messenger: Messenger,
+  log?: (...data: any[]) => void
+): Messenger {
+  log = log || debug('post-me');
+
+  const debugListener: MessageListener = function (event) {
+    const { data } = event;
+    log!('⬅️ received message', data);
+  };
+
+  messenger.addMessageListener(debugListener);
+
+  return {
+    postMessage: function (message) {
+      log!('➡️ sending message', message);
+      messenger.postMessage(message);
+    },
+    addMessageListener: function (listener) {
+      return messenger.addMessageListener(listener);
+    },
+  };
+}


### PR DESCRIPTION
I'm proposing an implementation to easily provide a visual debug of every message sent/received at the `Messenger` level.

Fixes: #16
Discussion from: #9 

Usage:
```typescript
import {
  ParentHandshake,
  WindowMessenger,
  DebugMessenger,
} from 'post-me';

// Use the full feature debugger with colors etc
import debug from 'debug';

// Or use the lite version provided in post-me (no colors, just plain text)
// import { debug } from 'post-me';

let messenger = new WindowMessenger({
  localWindow: window,
  remoteWindow: childWindow,
  remoteOrigin: '*'
});

const log = debug('post-me:parent');
messenger = DebugMessenger(messenger, log);

cost handshake = ParentHandshake({}, messenger);
...
```

What I like:
- Debugging at the `Messenger` level ensure that every single message exchanged gets logged.
- Debugging code is localized to a single 10 line function, instead of being scattered in several places such as the `Bridge`/`Handshake`.
- Since `DebugMessenger` is a decorator (i.e. takes a `Messenger` and returns a `Messenger`), it will automatically work with any new type of `Messenger` we may implement in the future.
- Zero runtime cost when debugging is disabled, don't even need to call no-op or have if/else checks, just don't decorate the `Messenger` before passing it to the handshake.
- The implementation works great with the popular `debug` library (see screenshot),

Here is a screenshot of the debug output of the demo application:
![ibridge_debug_output](https://user-images.githubusercontent.com/15913822/103419538-76160e80-4b61-11eb-89da-24f15a4fa74b.png)
