### PR TITLE
Add support for callbacks as call parameters

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -1,3 +1,5 @@
+export const MARKER = '@post-me';
+
 export type IdType = number;
 export type KeyType = string;
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,6 +1,4 @@
-import { IdType, KeyType } from './common';
-
-const MARKER = '@post-me';
+import { IdType, KeyType, MARKER } from './common';
 
 export enum MessageType {
   HandshakeRequest = 'handshake-request',
@@ -9,6 +7,7 @@ export enum MessageType {
   Response = 'response',
   Error = 'error',
   Event = 'event',
+  Callback = 'callback',
 }
 
 export interface Message<T extends MessageType> {
@@ -34,6 +33,13 @@ export interface ResponseMessage<R> extends Message<MessageType.Response> {
   requestId: IdType;
   result?: R;
   error?: string;
+}
+
+export interface CallbackMessage<A extends Array<any>>
+  extends Message<MessageType.Callback> {
+  requestId: IdType;
+  callbackId: IdType;
+  args: A;
 }
 
 export interface EventMessage<P> extends Message<MessageType.Event> {
@@ -67,7 +73,7 @@ export function createCallMessage<A extends Array<any>>(
   sessionId: IdType,
   requestId: IdType,
   methodName: KeyType,
-  ...args: A
+  args: A
 ): CallMessage<A> {
   return {
     type: MARKER,
@@ -101,6 +107,22 @@ export function createResponsMessage<R>(
   }
 
   return message;
+}
+
+export function createCallbackMessage<A extends Array<any>>(
+  sessionId: IdType,
+  requestId: IdType,
+  callbackId: IdType,
+  args: A
+): CallbackMessage<A> {
+  return {
+    type: MARKER,
+    action: MessageType.Callback,
+    sessionId,
+    requestId,
+    callbackId,
+    args,
+  };
 }
 
 export function createEventMessage<P>(
@@ -141,6 +163,10 @@ export function isCallMessage(m: Message<any>): m is CallMessage<any[]> {
 
 export function isResponseMessage(m: Message<any>): m is ResponseMessage<any> {
   return isMessage(m) && m.action === MessageType.Response;
+}
+
+export function isCallbackMessage(m: Message<any>): m is CallbackMessage<any> {
+  return isMessage(m) && m.action === MessageType.Callback;
 }
 
 export function isEventMessage(m: Message<any>): m is EventMessage<any> {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,26 @@
+import { MARKER, IdType } from './common';
+
+export enum ProxyType {
+  Callback = 'callback',
+}
+
+export interface BaseProxy<P extends ProxyType> {
+  type: typeof MARKER;
+  proxy: P;
+}
+
+export interface CallbackProxy extends BaseProxy<ProxyType.Callback> {
+  callbackId: IdType;
+}
+
+export function createCallbackProxy(callbackId: IdType): CallbackProxy {
+  return {
+    type: MARKER,
+    proxy: ProxyType.Callback,
+    callbackId,
+  };
+}
+
+export function isCallbackProxy(p: any): p is CallbackProxy {
+  return p.type === MARKER && p.proxy === ProxyType.Callback;
+}


### PR DESCRIPTION
Issue: #38 

With a little magic behind the scenes, we can now pass callback functions as parameters of method calls just like we would any other argument.

NOTE: if the callback returns a value, it will be ignored.

Usage:
Parent code
```javascript
//...
ParentHandshake(messenger).then(connection => {
  const remoteHandle = connection.remoteHandle();

  const onProgress = (progress) => {
    console.log(progress);
  }

  remoteHandle.call("slowSum", 2, 3, onProgress).then(result => {
    //...
  });
});
```

Worker code
```javascript
const methods = {
  slowSum: (x, y, onProgress) => {
    onProgress(0);
    onProgress(0.25);
    onProgress(0.5);
    onProgress(0.75);
    onProgress(1);

    return x + y;
}

// ...

ChildHandshake(messenger, methods).then(connection => {
  // ...
})
```
