### PR TITLE
Fix Error objects cannot be cloned across contexts

### DIFF
--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -104,6 +104,12 @@ export class Dispatcher extends ConcreteEmitter<DispatcherEvents> {
     error: any,
     transfer?: Transferable[]
   ) {
+    if (error instanceof Error) {
+      error = {
+        name: error.name,
+        message: error.message,
+      };
+    }
     const message = createResponsMessage(
       this.sessionId,
       requestId,


### PR DESCRIPTION
Only copying the name and message of the error for now,
can explore more sophisticates solutions in the future.