### PR TITLE
Call methods in the context of the object on which they are defined

### DIFF
--- a/packages/core/src/handles.ts
+++ b/packages/core/src/handles.ts
@@ -366,7 +366,7 @@ export class ConcreteLocalHandle<
         }
       });
 
-      Promise.resolve(method(...desanitizedArgs))
+      Promise.resolve(this._methods[methodName](...desanitizedArgs))
         .then(resolve)
         .catch(reject);
     });


### PR DESCRIPTION
This allows passing a class instance to implement methods such that the class instance is still able to access class members.

Without this change, the test added in this patch will fail with the following error:

```
  ● call:bound methods

    TypeError: Cannot read property 'magicNumber' of undefined
```

Fixes #59.